### PR TITLE
Experimentation with "task graphs"

### DIFF
--- a/modules/examples/src/main/scala/zio/backtask/examples/BacktaskApp.scala
+++ b/modules/examples/src/main/scala/zio/backtask/examples/BacktaskApp.scala
@@ -8,7 +8,7 @@ import zio.{ZIOAppDefault, *}
 
 import java.time.LocalDateTime
 
-object Tasks:
+private[this] object tasks:
   case class add(a: Int, b: Int, yes: Option[String] = None) extends Backtask[Any]:
     override def queueName = "math"
 
@@ -36,7 +36,7 @@ object Tasks:
       yield ()
 
 object BacktaskApp extends ZIOAppDefault:
-  import Tasks.*
+  import tasks.*
   override val bootstrap = Runtime.removeDefaultLoggers >>> SLF4J.slf4j
 
   def clientProgram: ZIO[Redis, Throwable, Unit] =

--- a/modules/examples/src/main/scala/zio/backtask/examples/GraphApp.scala
+++ b/modules/examples/src/main/scala/zio/backtask/examples/GraphApp.scala
@@ -1,0 +1,53 @@
+package zio.backtask.examples
+
+import zio.{IO, Runtime, ZIO, ZIOAppDefault}
+import zio.stream.ZStream.fromIterable
+import zio.Console.printLine
+import zio.logging.backend.SLF4J
+import zio.backtask.{Backtask, JobID, Redis, RedisClient}
+
+import scala.annotation.targetName
+import scala.concurrent.duration.*
+
+type TaskGraph[Env] = List[Backtask[Env]]
+object TaskGraph { def apply[T <: Backtask[Env], Env](task: T): TaskGraph[Env] = List(task); }
+given backtaskConversion[Env]: Conversion[Backtask[Env], TaskGraph[Env]] = task => TaskGraph(task)
+
+object Extensions:
+  extension [T <: Backtask[Env], Env](task: T)
+    def ++(otherTask: Backtask[Env]): TaskGraph[Env] = List(task, otherTask)
+    def ~>(otherTask: Backtask[Env]): Backtask[Env]  = task.withAfterTasks(otherTask)
+
+  extension [T >: Backtask[Env], Env](tasks: TaskGraph[Env])
+    def ++(otherTask: Backtask[Env]): TaskGraph[Env] = tasks ++ List(otherTask)
+    def performAsync: ZIO[Redis, Throwable, Unit]    = fromIterable(tasks).mapZIO(_.performAsync).runDrain
+
+private[this] object UserTasks:
+  case class Say(input: String) extends Backtask[Any] { def run = printLine(input); }
+
+private[this] object UserGraphs:
+  import Extensions.*; import UserTasks.*
+
+  val g1: TaskGraph[Any] = Say("A") ++ Say("B").withDelay(10.seconds) ++ Say("C") ++ Say("D")
+
+  val g2: TaskGraph[Any] = (
+    Say("A") ~> Say("B") ~> Say("C").withDelay(1.hour)
+  ) ++ Say("X") ++ Say("Z") ~> Say("Y")
+
+  val g3: TaskGraph[Any] =
+    Say("send email") ~> Say("send another email") ++
+      Say("scrape something").withDelay(1.day) ~> Say("send another email")
+      ~> Say("have fun").repeatN(2)
+
+object GraphApp extends ZIOAppDefault:
+  import Extensions.*; import UserGraphs.*
+  override val bootstrap = Runtime.removeDefaultLoggers >>> SLF4J.slf4j
+
+  def program =
+    for
+      _ <- g1.performAsync
+      _ <- g2.performAsync
+      _ <- g3.performAsync
+    yield ()
+
+  def run = program.provideLayer(RedisClient.live)

--- a/modules/library/src/main/scala/zio/backtask/BacktaskScheduler.scala
+++ b/modules/library/src/main/scala/zio/backtask/BacktaskScheduler.scala
@@ -19,9 +19,7 @@ object BacktaskScheduler:
       for
         key  <- succeed(s"queue:$default")
         jobs <- rpop(key, batchSize)
-        _    <- when(jobs.nonEmpty) {
-          lpush(now, jobs: _*).flatMap(logMove(key))
-        }
+        _    <- when(jobs.nonEmpty)(lpush(now, jobs: _*).flatMap(logMove(key)))
       yield ()
     else
       for
@@ -31,9 +29,7 @@ object BacktaskScheduler:
           (0, batchSize)
         )
         _    <- when(jobs.nonEmpty) {
-          (lpush(now, jobs: _*).flatMap(logMove("*")) <&>
-            zrem(s"queue:$queueName", jobs: _*)) *>
-            logDebug(s"Jobs moved to now: ${jobs.length}")
+          lpush(now, jobs: _*).flatMap(logMove("*")) <&> zrem(s"queue:$queueName", jobs: _*)
         }
       yield ()
 


### PR DESCRIPTION
I had this idea of graphs of tasks where one could create a task if one task succeeded, and tasks could be scheduled via lovely "DSL".

Examples:

```scala
  val g1: TaskGraph[Any] = Say("A") ++ Say("B").withDelay(10.seconds) ++ Say("C") ++ Say("D")

  val g2: TaskGraph[Any] = (
    Say("A") ~> Say("B") ~> Say("C").withDelay(1.hour)
  ) ++ Say("X") ++ Say("Z") ~> Say("Y")

  val g3: TaskGraph[Any] =
    Say("send email") ~> Say("send another email") ++
      Say("scrape something").withDelay(1.day) ~> Say("send another email")
      ~> Say("have fun").repeatN(2)
```

And then enqueue the whole graph trivially as 

```scala
  def program =
    for
      _ <- g1.performAsync
      _ <- g2.performAsync
      _ <- g3.performAsync
    yield ()

```